### PR TITLE
Using replace() instead of replaceAll() for non-regex patterns

### DIFF
--- a/src/main/java/org/apache/joshua/corpus/syntax/ArraySyntaxTree.java
+++ b/src/main/java/org/apache/joshua/corpus/syntax/ArraySyntaxTree.java
@@ -368,7 +368,7 @@ public class ArraySyntaxTree implements SyntaxTree, Externalizable {
 
   // TODO: could make this way more efficient
   private void appendFromPennFormat(String line) {
-    String[] tokens = line.replaceAll("\\(", " ( ").replaceAll("\\)", " ) ").trim().split("\\s+");
+    String[] tokens = line.replace("\\(", " ( ").replace("\\)", " ) ").trim().split("\\s+");
 
     boolean next_nt = false;
     int current_id = 0;

--- a/src/main/java/org/apache/joshua/corpus/syntax/ArraySyntaxTree.java
+++ b/src/main/java/org/apache/joshua/corpus/syntax/ArraySyntaxTree.java
@@ -368,7 +368,7 @@ public class ArraySyntaxTree implements SyntaxTree, Externalizable {
 
   // TODO: could make this way more efficient
   private void appendFromPennFormat(String line) {
-    String[] tokens = line.replace("\\(", " ( ").replace("\\)", " ) ").trim().split("\\s+");
+    String[] tokens = line.replaceAll("\\(", " ( ").replaceAll("\\)", " ) ").trim().split("\\s+");
 
     boolean next_nt = false;
     int current_id = 0;

--- a/src/main/java/org/apache/joshua/decoder/ff/FeatureVector.java
+++ b/src/main/java/org/apache/joshua/decoder/ff/FeatureVector.java
@@ -338,7 +338,7 @@ public class FeatureVector {
 
     // First print all the dense feature names in order
     for (int i = 0; i < DENSE_FEATURE_NAMES.size(); i++) {
-      outputString.append(String.format("%s=%.3f ", DENSE_FEATURE_NAMES.get(i).replaceAll("_", "-"), getDense(i)));
+      outputString.append(String.format("%s=%.3f ", DENSE_FEATURE_NAMES.get(i).replace("_", "-"), getDense(i)));
       printed_keys.add(DENSE_FEATURE_NAMES.get(i));
     }
 

--- a/src/main/java/org/apache/joshua/mira/MIRACore.java
+++ b/src/main/java/org/apache/joshua/mira/MIRACore.java
@@ -2795,11 +2795,11 @@ public class MIRACore {
       return str;
 
     // replace HTML/SGML
-    str = str.replaceAll("&quot;", "\"");
-    str = str.replaceAll("&amp;", "&");
-    str = str.replaceAll("&lt;", "<");
-    str = str.replaceAll("&gt;", ">");
-    str = str.replaceAll("&apos;", "'");
+    str = str.replace("&quot;", "\"");
+    str = str.replace("&amp;", "&");
+    str = str.replace("&lt;", "<");
+    str = str.replace("&gt;", ">");
+    str = str.replace("&apos;", "'");
 
     // split on these characters:
     // ! " # $ % & ( ) * + / : ; < = > ? @ [ \ ] ^ _ ` { | } ~

--- a/src/main/java/org/apache/joshua/util/FormatUtils.java
+++ b/src/main/java/org/apache/joshua/util/FormatUtils.java
@@ -122,9 +122,9 @@ public class FormatUtils {
   }
   
   public static String escapeSpecialSymbols(String s) {
-    return s.replace("\\[",  "-lsb-")
-            .replace("\\]",  "-rsb-")
-            .replace("\\|",  "-pipe-");
+    return s.replaceAll("\\[",  "-lsb-")
+            .replaceAll("\\]",  "-rsb-")
+            .replaceAll("\\|",  "-pipe-");
   }
   
   public static String unescapeSpecialSymbols(String s) {

--- a/src/main/java/org/apache/joshua/util/FormatUtils.java
+++ b/src/main/java/org/apache/joshua/util/FormatUtils.java
@@ -122,15 +122,15 @@ public class FormatUtils {
   }
   
   public static String escapeSpecialSymbols(String s) {
-    return s.replaceAll("\\[",  "-lsb-")
-            .replaceAll("\\]",  "-rsb-")
-            .replaceAll("\\|",  "-pipe-");
+    return s.replace("\\[",  "-lsb-")
+            .replace("\\]",  "-rsb-")
+            .replace("\\|",  "-pipe-");
   }
   
   public static String unescapeSpecialSymbols(String s) {
-    return s.replaceAll("-lsb-", "[")
-            .replaceAll("-rsb-", "]")
-            .replaceAll("-pipe-", "|");
+    return s.replace("-lsb-", "[")
+            .replace("-rsb-", "]")
+            .replace("-pipe-", "|");
   }
   
   /**

--- a/src/main/java/org/apache/joshua/zmert/MertCore.java
+++ b/src/main/java/org/apache/joshua/zmert/MertCore.java
@@ -2597,11 +2597,11 @@ public class MertCore {
     if (normMethod == 0) return str;
 
     // replace HTML/SGML
-    str = str.replaceAll("&quot;", "\"");
-    str = str.replaceAll("&amp;", "&");
-    str = str.replaceAll("&lt;", "<");
-    str = str.replaceAll("&gt;", ">");
-    str = str.replaceAll("&apos;", "'");
+    str = str.replace("&quot;", "\"");
+    str = str.replace("&amp;", "&");
+    str = str.replace("&lt;", "<");
+    str = str.replace("&gt;", ">");
+    str = str.replace("&apos;", "'");
 
 
 


### PR DESCRIPTION
[JOSHUA-342](https://issues.apache.org/jira/browse/JOSHUA-342) Using replace() instead replaceAll() when no regex is used removes the overhead associated with replaceAll()