### PR TITLE
Add OpenJDK dependency required for "jni.h"

### DIFF
--- a/distribution/docker/kenlm/Dockerfile
+++ b/distribution/docker/kenlm/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update && \
             liblzma-dev \            
             libz-dev \
             make \
-            curl
+            curl \
+            openjdk-8-jdk
 
 # set environment variables
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/


### PR DESCRIPTION
Fixes docker build: Solves

```
100%] Linking CXX executable ../tests/model_test
[100%] Built target model_test
/code/jni/kenlm_wrap.cc:28:17: fatal error: jni.h: No such file or directory
 #include <jni.h>
                 ^
compilation terminated.
Removing intermediate container 0c2cb0c17a12

```